### PR TITLE
Checks oauth response is expected type

### DIFF
--- a/src/OAuth/FortifiProvider.php
+++ b/src/OAuth/FortifiProvider.php
@@ -260,15 +260,11 @@ class FortifiProvider extends AbstractProvider
    */
   protected function checkResponse(ResponseInterface $response, $data)
   {
-    $dataIsArray = is_array($data);
-    if($response->getStatusCode() != 200 || !$dataIsArray)
+    if($response->getStatusCode() != 200 || !is_array($data))
     {
-      if(!$dataIsArray)
-      {
-        $data = [$data];
-      }
+      $data = ValueAs::arr($data);
       $msg = Arrays::value($data, 'message', 'An unknown error occurred');
-      throw new IdentityProviderException($msg, $response->getStatusCode(), (array)$data);
+      throw new IdentityProviderException($msg, $response->getStatusCode(), $data);
     }
   }
 

--- a/src/OAuth/FortifiProvider.php
+++ b/src/OAuth/FortifiProvider.php
@@ -260,8 +260,13 @@ class FortifiProvider extends AbstractProvider
    */
   protected function checkResponse(ResponseInterface $response, $data)
   {
-    if($response->getStatusCode() != 200)
+    $dataIsArray = is_array($data);
+    if($response->getStatusCode() != 200 || !$dataIsArray)
     {
+      if(!$dataIsArray)
+      {
+        $data = [$data];
+      }
       $msg = Arrays::value($data, 'message', 'An unknown error occurred');
       throw new IdentityProviderException($msg, $response->getStatusCode(), (array)$data);
     }


### PR DESCRIPTION
This pull request has additional type checks for oauth response $data object. If the object is not of expected type then the data will be returned in an error response.

This prevents the error below occurring in an edge case where the oauth response is not a JSON structure, does not have 'application\json' content type and does not have response code 500.

```php
NOTICE: PHP message: PHP Fatal error: Uncaught TypeError: Argument 1 passed to Packaged\Helpers\Arrays::value() must be of the type array, string given, called in.....
```